### PR TITLE
fix: flock patch for +v1.11.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ For more background and details, see also:
 
 **OS:** Ubuntu 20.04, Linux Kernel >= 5.11
 
-**go-ethereum:** v1.10.22 until v1.11.2 supported
+**go-ethereum:** v1.10.22 and up supported
 
 **Hardware:** CPU supporting SGX2 (Intel Skylake and newer), +64GB EPC Enclave Memory (for mainnet), +1TB Swap (for mainnet)
 

--- a/geth-patches/0001a-go-ethereum.patch
+++ b/geth-patches/0001a-go-ethereum.patch
@@ -1,0 +1,40 @@
+diff --git a/go.mod b/go.mod
+index 4a769c7a2..478759025 100644
+--- a/go.mod
++++ b/go.mod
+@@ -1,1 +1,3 @@
+ module github.com/ethereum/go-ethereum
++
++replace github.com/syndtr/goleveldb => ../goleveldb
+diff --git a/core/rawdb/freezer.go b/core/rawdb/freezer.go
+index 60e2c56e0..8cb9c2719 100644
+--- a/core/rawdb/freezer.go
++++ b/core/rawdb/freezer.go
+@@ -111,11 +111,6 @@ func NewFreezer(datadir string, namespace string, readonly bool, maxTableSize ui
+ 	// Leveldb uses LOCK as the filelock filename. To prevent the
+ 	// name collision, we use FLOCK as the lock name.
+ 	lock := flock.New(flockFile)
+-	if locked, err := lock.TryLock(); err != nil {
+-		return nil, err
+-	} else if !locked {
+-		return nil, errors.New("locking failed")
+-	}
+ 	// Open all the supported data tables
+ 	freezer := &Freezer{
+ 		readonly:     readonly,
+diff --git a/node/node.go b/node/node.go
+index 2f89bc1ad..57dc22d54 100644
+--- a/node/node.go
++++ b/node/node.go
+@@ -322,11 +322,6 @@ func (n *Node) openDataDir() error {
+ 	// accidental use of the instance directory as a database.
+ 	n.dirLock = flock.New(filepath.Join(instdir, "LOCK"))
+ 
+-	if locked, err := n.dirLock.TryLock(); err != nil {
+-		return err
+-	} else if !locked {
+-		return ErrDatadirUsed
+-	}
+ 	return nil
+ }
+ 


### PR DESCRIPTION
Adds a new patch for geth +v1.11.3, where file locks are called differently. Has been tested on sepolia.